### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run Multi-URL Screenshots on TestMu AI (Formerly LambdaTest)
+﻿# Run Multi-URL Screenshots on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can take automated screenshots across 
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) 8 or higher.
+- Node.js 8 or higher.
 - Git installed.
-- A [TestMu AI account](https://www.testmuai.com/register/). Retrieve your **Username** and **Access Key** from the [TestMu AI Automation Dashboard](https://automation.testmuai.com/).
+- A TestMu AI account. Retrieve your **Username** and **Access Key** from the TestMu AI Automation Dashboard.
 
 ### Setup
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.