### PR TITLE
fix: update README branding and remove non-template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can take automated screenshots across 
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) 8 or higher.
+- Node.js 8 or higher.
 - Git installed.
-- A [TestMu AI account](https://www.testmuai.com/register/). Retrieve your **Username** and **Access Key** from the [TestMu AI Automation Dashboard](https://automation.testmuai.com/).
+- A TestMu AI account. Retrieve your **Username** and **Access Key** from the TestMu AI Automation Dashboard.
 
 ### Setup
 


### PR DESCRIPTION
- Replace standalone LambdaTest with TestMu AI (Formerly LambdaTest) in body text\n- Remove non-template links from Prerequisites/Setup/Run tests sections